### PR TITLE
Possible error on Camp

### DIFF
--- a/scripts/data_armies.ttslua
+++ b/scripts/data_armies.ttslua
@@ -158,8 +158,7 @@ armies = {
                 fixed_models = {
                     [1] = 'troop_artillery_crew_swiss',
                     [2] = 'troop_artillery_pieces_swiss',
-                    [3] = 'troop_artillery_crew_swiss',
-                    [3] = 'troop_artillery_crew_swiss',
+                    [3] = 'troop_artillery_crew_swiss'
                 }
             },
             base15 = {


### PR DESCRIPTION
Despite n_models was equal to 3, there were 4 lines in "fixed models", the fourth was [3] again, and ending with a comma. This might be an error because of both the fourth model and the ending comma.