### PR TITLE
Several Knights changes

### DIFF
--- a/scripts/data_armies.ttslua
+++ b/scripts/data_armies.ttslua
@@ -168,7 +168,7 @@ armies = {
                 base = 'tile_grass_40x30',
                 n_models = 3,
                 fixed_models = {
-                    [1] = 'troop_knight_late_medieval',
+                    [1] = 'troop_knight_late_medieval_bannerman',
                     [2] = 'troop_knight_late_medieval_captain',
                     [3] = 'troop_knight_late_medieval'
                 }
@@ -313,7 +313,7 @@ armies = {
                 fixed_models = {
                     [1] = 'troop_knight_late_medieval',
                     [2] = 'troop_knight_late_medieval_captain',
-                    [3] = 'troop_knight_late_medieval'
+                    [3] = 'troop_knight_late_medieval_bannerman'
                 }
             },
             base2 = {
@@ -429,7 +429,7 @@ armies = {
                 fixed_models = {
                     [1] = 'troop_knight_late_medieval',
                     [2] = 'troop_knight_late_medieval_captain',
-                    [3] = 'troop_knight_late_medieval'
+                    [3] = 'troop_knight_late_medieval_bannerman'
                 }
             },
             base2 = {
@@ -554,7 +554,7 @@ armies = {
                 base = 'tile_grass_40x30',
                 n_models = 3,
                 fixed_models = {
-                    [1] = 'troop_knight_late_medieval',
+                    [1] = 'troop_knight_late_medieval_bannerman',
                     [2] = 'troop_knight_late_medieval_captain',
                     [3] = 'troop_knight_late_medieval'
                 }
@@ -730,7 +730,7 @@ armies = {
                 fixed_models = {
                     [1] = 'troop_knight_late_medieval',
                     [2] = 'troop_knight_late_medieval_captain',
-                    [3] = 'troop_knight_late_medieval'
+                    [3] = 'troop_knight_late_medieval_bannerman'
                 }
             },
             base2 = {

--- a/scripts/data_troops.ttslua
+++ b/scripts/data_troops.ttslua
@@ -675,8 +675,8 @@ troop_horse_rider_late_medieval = {
         'http://cloud-3.steamusercontent.com/ugc/1011564617603302385/DF9AA138A32409343E12624A1356AF414CE07553/',
         'http://cloud-3.steamusercontent.com/ugc/1011564617603303443/D02EFC330CC3BEB32F2F60FBAA2B3B221B845F29/'
     },
-    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691108385801708/97CF34AEA13AE496582B57D68B77613133B08C10/',
-    player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691108385800537/21A78C9FB12E9D90CE28EBD4C3CA36BD5DA4DB17/'
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691328068100647/3A9FF49FF24D2E6A3B140FD34769C5B71222504C/',
+    player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691328068101058/6F8A8AC48C788DA465D7A8FEA1AB18D237B93995/'
 }
 
 troop_knight_late_medieval = {
@@ -693,21 +693,34 @@ troop_knight_late_medieval = {
         'http://cloud-3.steamusercontent.com/ugc/1011564617603277713/CFCC1F9B4843E85BA9173BA77E2A8A81E24041D1/',
         'http://cloud-3.steamusercontent.com/ugc/1011564617603277965/F09D7ACC7495FF75F6FBFE6F3C40E72A38796422/'
     },
-    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691108385801708/97CF34AEA13AE496582B57D68B77613133B08C10/',
-    player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691108385800537/21A78C9FB12E9D90CE28EBD4C3CA36BD5DA4DB17/'
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691328068100647/3A9FF49FF24D2E6A3B140FD34769C5B71222504C/',
+    player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691328068101058/6F8A8AC48C788DA465D7A8FEA1AB18D237B93995/'
 }
 
 troop_knight_late_medieval_captain = {
     height_correction = 0.71,
     scale = 0.37,
     rotation = 180,
-    description = 'Late Medieval Knight',
-    author = 'Late Medieval Knight, using Empire Knights by Vess (edited by Arkein).',
+    description = 'Late Medieval Knight Captain',
+    author = 'Late Medieval Knight Captain, using Empire Knights by Vess (edited by Arkein).',
     mesh = {
-        'http://cloud-3.steamusercontent.com/ugc/1011564617603278252/35BDEF46E8579A093A740773A4D2CCA17E3FD1AF/'
+        'http://cloud-3.steamusercontent.com/ugc/1012691328068160719/5BDC02DDF0EC04136303C9496A7F4D44CAB6C534/'
     },
-    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691108385801708/97CF34AEA13AE496582B57D68B77613133B08C10/',
-    player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691108385800537/21A78C9FB12E9D90CE28EBD4C3CA36BD5DA4DB17/'
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691328068100647/3A9FF49FF24D2E6A3B140FD34769C5B71222504C/',
+    player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691328068101058/6F8A8AC48C788DA465D7A8FEA1AB18D237B93995/'
+}
+
+troop_knight_late_medieval_bannerman = {
+    height_correction = 0.71,
+    scale = 0.37,
+    rotation = 180,
+    description = 'Late Medieval Knight Bannerman',
+    author = 'Late Medieval Knight Bannerman, using Empire Knights by Vess (edited by Arkein).',
+    mesh = {
+        'http://cloud-3.steamusercontent.com/ugc/1012691328068168329/8D7E1A9C8945E0B22C56E0D0D546F2CFFBF34CFF/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691328068100647/3A9FF49FF24D2E6A3B140FD34769C5B71222504C/',
+    player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691328068101058/6F8A8AC48C788DA465D7A8FEA1AB18D237B93995/'
 }
 
 troop_camp_late_medieval = {


### PR DESCRIPTION
A few things:

- General Knight now displays the sword in a different position, it holds it pointing laterally. Sometimes with the random rotation the sword now go through the knight on its side, could we fix captain's position somehow? Maybe the captain can go on the front and the other two more on the back, as we do on real models.

- General Knight model changes UVs on shoulders, horse's head's plate and horse's back plates and now their borders are golden. Also on horse's front barding, golden too in both armies (no red or blue, I saw no conflict). Because it means higher status. No changes on texture for it, the texture already had all that.

- Added one extra troop, knight bannerman. It now displays a huge banner to help identifying the General base. Took it from the third knight model, erased the lance and added the banner.

- Changed all rider's texture because of the bannerman adition. Took the same banner texture from the infantry (long spear and banner). I didn't erase any other part from the previous texture, there was room enough for it.