### PR TITLE
War wagon, spearmen, and textures

### DIFF
--- a/scripts/data_armies.ttslua
+++ b/scripts/data_armies.ttslua
@@ -50,7 +50,237 @@ armies = {
             }
         }
     },
-    Book_IV = {
+      Book_IV = {
+        IV_13c_Medieval_German_1450AD_to_1478AD = {
+            data = {
+                aggresiveness = 1,
+                terrain = 'Arable',
+                list = '1x6Kn (Gen), 2x6Kn, 1x3Cv, 2x4Pk, 2x3/4Sp, 1x4Cb or 2Ps, 2xWWg, 1xArt.'
+            },
+            base1 = {
+                name = '6Kn_Gen',
+                base = 'tile_grass_40x60',
+                n_models = 6,
+                fixed_models = {
+                    [1] = 'troop_knight_late_medieval_bannerman',
+                    [2] = 'troop_knight_late_medieval',
+                    [3] = 'troop_knight_late_medieval',
+                    [4] = 'troop_knight_late_medieval',
+                    [5] = 'troop_knight_late_medieval_captain',
+                    [6] = 'troop_knight_late_medieval_bannerman'
+                }
+            },
+            base2 = {
+                name = '6Kn',
+                base = 'tile_grass_40x60',
+                n_models = 6,
+                model_data = 'troop_knight_late_medieval'
+            },
+            base3 = {
+                name = '6Kn',
+                base = 'tile_grass_40x60',
+                n_models = 6,
+                model_data = 'troop_knight_late_medieval'
+            },
+            base4 = {
+                name = '3Cv',
+                base = 'tile_grass_40x30',
+                n_models = 3,
+                model_data = 'troop_horse_rider_late_medieval'
+            },
+            base5 = {
+                name = '4Pk',
+                base = 'tile_grass_40x15',
+                n_models = 4,
+                model_data = 'troop_pikeman_swiss_straight'
+            },
+            base6 = {
+                name = '4Pk',
+                base = 'tile_grass_40x15',
+                n_models = 4,
+                model_data = 'troop_pikeman_swiss_inclined'
+            },
+            base7 = {
+                name = '4Sp',
+                base = 'tile_grass_40x15',
+                n_models = 4,
+                model_data = 'troop_spearman_late_medieval'
+            },
+            base8 = {
+                name = '4Sp',
+                base = 'tile_grass_40x15',
+                n_models = 4,
+                model_data = 'troop_spearman_late_medieval'
+            },
+            base9 = {
+                name = '3Sp',
+                base = 'tile_grass_40x20',
+                n_models = 3,
+                model_data = 'troop_spearman_no_shield_late_medieval'
+            },
+            base10 = {
+                name = '3Sp',
+                base = 'tile_grass_40x20',
+                n_models = 3,
+                model_data = 'troop_spearman_no_shield_late_medieval'
+            },
+            base11 = {
+                name = '4Cb',
+                base = 'tile_grass_40x20',
+                n_models = 4,
+                model_data = 'troop_crossbowman_late_medieval'
+            },
+            base12 = {
+                name = '2Ps',
+                base = 'tile_grass_40x20',
+                n_models = 2,
+                model_data = 'troop_bowman_late_medieval'
+            },
+            base13 = {
+                name = 'WWg',
+                base = 'tile_grass_40x80',
+                n_models = 1,
+                model_data = 'troop_war_wagon_late_medieval'
+            },
+            base14 = {
+                name = 'WWg',
+                base = 'tile_grass_40x80',
+                n_models = 1,
+                model_data = 'troop_war_wagon_late_medieval'
+            },
+            base15 = {
+                name = '4Cb',
+                base = 'tile_grass_40x20',
+                n_models = 4,
+                model_data = 'troop_crossbowman_late_medieval'
+            },
+            base16 = {
+                name = '4Cb',
+                base = 'tile_grass_40x20',
+                n_models = 4,
+                model_data = 'troop_crossbowman_late_medieval'
+            },
+            base17 = {
+                name = 'Art',
+                base = 'tile_grass_40x40',
+                n_models = 3,
+                fixed_models = {
+                    [1] = 'troop_artillery_crew_late_medieval',
+                    [2] = 'troop_artillery_pieces_late_medieval',
+                    [3] = 'troop_artillery_crew_late_medieval'
+                }
+            },
+            base18 = {
+                name = 'Camp',
+                base = 'tile_grass_40x40',
+                n_models = 1,
+                model_data = 'troop_camp_late_german'
+            }
+        },
+        IV_13d_Medieval_German_1450AD_to_1478AD = {
+            data = {
+                aggresiveness = 1,
+                terrain = 'Arable',
+                list = '1x6Kn (Gen), 2x6Kn, 1x3Cv, 2x4Pk, 2x3/4Sp, 1x4Cb or 2Ps, 2xWWg, 1xArt.'
+            },
+            base1 = {
+                name = '3Kn_Gen',
+                base = 'tile_grass_40x30',
+                n_models = 3,
+                fixed_models = {
+                    [1] = 'troop_knight_late_medieval_bannerman',
+                    [2] = 'troop_knight_late_medieval_captain',
+                    [3] = 'troop_knight_late_medieval'
+                }
+            },
+            base2 = {
+                name = '4Pk_Gen',
+                base = 'tile_grass_40x15',
+                n_models = 4,
+                fixed_models = {
+                    [1] = 'troop_pikeman_late_medieval_straight',
+                    [2] = 'troop_pikeman_late_medieval_captain',
+                    [3] = 'troop_pikeman_late_medieval_bannerman',
+                    [4] = 'troop_pikeman_late_medieval_straight',
+                }
+            },
+            base3 = {
+                name = '3Kn',
+                base = 'tile_grass_40x30',
+                n_models = 3,
+                model_data = 'troop_knight_late_medieval'
+            },
+            base4 = {
+                name = '6Kn',
+                base = 'tile_grass_40x60',
+                n_models = 6,
+                model_data = 'troop_knight_late_medieval'
+            },
+            base5 = {
+                name = '6Kn',
+                base = 'tile_grass_40x60',
+                n_models = 6,
+                model_data = 'troop_knight_late_medieval'
+            },
+            base6 = {
+                name = '3Cv',
+                base = 'tile_grass_40x30',
+                n_models = 3,
+                model_data = 'troop_horse_rider_late_medieval'
+            },
+            base7 = {
+                name = '4Pk',
+                base = 'tile_grass_40x15',
+                n_models = 4,
+                model_data = 'troop_pikeman_late_medieval_straight'
+            },
+            base8 = {
+                name = '4Pk',
+                base = 'tile_grass_40x15',
+                n_models = 4,
+                model_data = 'troop_pikeman_late_medieval_inclined'
+            },
+            base9 = {
+                name = '4Pk',
+                base = 'tile_grass_40x15',
+                n_models = 4,
+                model_data = 'troop_pikeman_late_medieval_inclined'
+            },
+            base10 = {
+                name = '2Ps',
+                base = 'tile_grass_40x20',
+                n_models = 2,
+                model_data = 'troop_bowman_late_medieval'
+            },
+            base11 = {
+                name = 'WWg',
+                base = 'tile_grass_40x80',
+                n_models = 1,
+                model_data = 'troop_war_wagon_late_medieval'
+            },
+            base12 = {
+                name = 'WWg',
+                base = 'tile_grass_40x80',
+                n_models = 1,
+                model_data = 'troop_war_wagon_late_medieval'
+            },
+            base13 = {
+                name = 'Art',
+                base = 'tile_grass_40x40',
+                n_models = 3,
+                fixed_models = {
+                    [1] = 'troop_artillery_crew_late_medieval',
+                    [2] = 'troop_artillery_pieces_late_medieval',
+                    [3] = 'troop_artillery_crew_late_medieval'
+                }
+            },
+            base14 = {
+                name = 'Camp',
+                base = 'tile_grass_40x40',
+                n_models = 1,
+                model_data = 'troop_camp_late_german'
+            }
+        },
         IV_79_Late_Swiss_1400AD_to_1522AD = {
             data = {
                 aggresiveness = 3,
@@ -303,7 +533,7 @@ armies = {
         IV_82b_French_Ordonnances_1465AD_to_1503AD = {
             data = {
                 aggresiveness = 2,
-                terrain = 'Arable',                
+                terrain = 'Arable',
                 list = '1x3Kn (Gen), 4x3Kn, 1x3Cv//4Bw, 1x4Cb, 2x4Pk (Swiss if not allies) or 3Bw, 2x2Ps, 1xArt.'
             },
             base1 = {

--- a/scripts/data_troops.ttslua
+++ b/scripts/data_troops.ttslua
@@ -387,8 +387,8 @@ troop_pikeman_late_medieval_inclined = {
         'http://cloud-3.steamusercontent.com/ugc/1011564198059105755/4775664482748F772637DBB58CD46D1385E06919/',
         'http://cloud-3.steamusercontent.com/ugc/1011564198059106092/22C4BA8CCD7CF144C0D6DE57689E59BC5C2E23F3/'
     },
-    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691209063381845/5B391F2A750B852786D95A10BEBEB61146C98638/',
-    player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691209063382179/30899673366803E55F42EF7262BA1086D1778B22/'
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691401814459030/CC29D45DDBE1A471538B7E78ACA097D527B8F8CC/',
+    player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691401814458523/75C0C25445C1D8DE41B6FE5790B519C382B2ADAF/'
 }
 
 troop_pikeman_late_medieval_straight = {
@@ -403,8 +403,8 @@ troop_pikeman_late_medieval_straight = {
         'http://cloud-3.steamusercontent.com/ugc/1011564198059105255/0742BCCB70B4384839675E41E2046A9A8B57BA2E/',
         'http://cloud-3.steamusercontent.com/ugc/1011564198059106409/4C2922D44C8723F3896C9490E5E3C9CDCC5483FD/'
     },
-    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691209063381845/5B391F2A750B852786D95A10BEBEB61146C98638/',
-    player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691209063382179/30899673366803E55F42EF7262BA1086D1778B22/'
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691401814459030/CC29D45DDBE1A471538B7E78ACA097D527B8F8CC/',
+    player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691401814458523/75C0C25445C1D8DE41B6FE5790B519C382B2ADAF/'
 }
 
 troop_pikeman_late_medieval_bannerman = {
@@ -416,8 +416,8 @@ troop_pikeman_late_medieval_bannerman = {
     mesh = {
         'http://cloud-3.steamusercontent.com/ugc/1011563720479886715/C4A1AB92BBFD82A9B1F3BFA1363EFFA69690F66D/'
     },
-    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691209063381845/5B391F2A750B852786D95A10BEBEB61146C98638/',
-    player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691209063382179/30899673366803E55F42EF7262BA1086D1778B22/'
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691401814459030/CC29D45DDBE1A471538B7E78ACA097D527B8F8CC/',
+    player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691401814458523/75C0C25445C1D8DE41B6FE5790B519C382B2ADAF/'
 }
 
 troop_pikeman_late_medieval_captain = {
@@ -429,15 +429,15 @@ troop_pikeman_late_medieval_captain = {
     mesh = {
         'http://cloud-3.steamusercontent.com/ugc/1011563720479888273/0FE163F87747C3B6E5BED19C5F99EF3C6733A8DE/'
     },
-    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691209063381845/5B391F2A750B852786D95A10BEBEB61146C98638/',
-    player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691209063382179/30899673366803E55F42EF7262BA1086D1778B22/'
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691401814459030/CC29D45DDBE1A471538B7E78ACA097D527B8F8CC/',
+    player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691401814458523/75C0C25445C1D8DE41B6FE5790B519C382B2ADAF/'
 }
 
 troop_spearman_no_shield_late_medieval = {
     height_correction = 0.36,
     scale = 0.37,
     rotation = 180,
-    description = 'Late Medieval Spearman',
+    description = 'Late Medieval Spearman Without Shield',
     author = 'Late Medieval Spearman, using Empire Spearman by Vess (edited by Arkein).',
     mesh = {
         'http://cloud-3.steamusercontent.com/ugc/1012691108385888219/0DED34571B666B38CA1AEC08DE82F31FC6C8D762/',
@@ -448,8 +448,27 @@ troop_spearman_no_shield_late_medieval = {
         'http://cloud-3.steamusercontent.com/ugc/1012691108385891578/AFEE9D10B064BF056AFE60839ABC8F6A86F27897/',
         'http://cloud-3.steamusercontent.com/ugc/1012691108385891865/BD9350FF71243667CFC1F22E899F1D254EA90248/'
     },
-    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691209063381845/5B391F2A750B852786D95A10BEBEB61146C98638/',
-    player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691209063382179/30899673366803E55F42EF7262BA1086D1778B22/'
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691401814459030/CC29D45DDBE1A471538B7E78ACA097D527B8F8CC/',
+    player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691401814458523/75C0C25445C1D8DE41B6FE5790B519C382B2ADAF/'
+}
+
+troop_spearman_late_medieval = {
+    height_correction = 0.36,
+    scale = 0.37,
+    rotation = 180,
+    description = 'Late Medieval Spearman',
+    author = 'Late Medieval Spearman, using Empire Spearman by Vess (edited by Arkein).',
+    mesh = {
+        'http://cloud-3.steamusercontent.com/ugc/1012691401814502586/EC2F572F2B09B3A4F07FD0F632C47BC972178615/',
+        'http://cloud-3.steamusercontent.com/ugc/1012691401814502857/A16D036AD412A7A0E5A8F4B22CDF2D02A698D463/',
+        'http://cloud-3.steamusercontent.com/ugc/1012691401814503146/7B2D8BE462FDE4CA6202C35588CE2A2FEB9AF451/',
+        'http://cloud-3.steamusercontent.com/ugc/1012691401814503414/5F03DBC9F020E99E1FCC99324B801FC22CA1822C/',
+        'http://cloud-3.steamusercontent.com/ugc/1012691401814503721/87D76A4E951499EA56CAC7EAF9392B7DC6FA917E/',
+        'http://cloud-3.steamusercontent.com/ugc/1012691401814503966/E25656EFE38828CA0A1CC7790C32438F54AF69AB/',
+        'http://cloud-3.steamusercontent.com/ugc/1012691401814504230/B72EBB33BECFAC2D0C41A20973B848F9EDA30069/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691401814459030/CC29D45DDBE1A471538B7E78ACA097D527B8F8CC/',
+    player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691401814458523/75C0C25445C1D8DE41B6FE5790B519C382B2ADAF/'
 }
 
 troop_handgunner_late_medieval = {
@@ -488,8 +507,8 @@ troop_handgunner_late_medieval = {
         'http://cloud-3.steamusercontent.com/ugc/1011564617603378971/708B60DC4BD6805B99203ECFFCDFD7BF68025592/',
         'http://cloud-3.steamusercontent.com/ugc/1011564617603379331/A211DAA7DFEAD2213ACD2190D95D10937C205C21/'
     },
-    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691209063381845/5B391F2A750B852786D95A10BEBEB61146C98638/',
-    player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691209063382179/30899673366803E55F42EF7262BA1086D1778B22/'
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691401814459030/CC29D45DDBE1A471538B7E78ACA097D527B8F8CC/',
+    player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691401814458523/75C0C25445C1D8DE41B6FE5790B519C382B2ADAF/'
 }
 
 troop_halberdier_late_medieval = {
@@ -508,8 +527,8 @@ troop_halberdier_late_medieval = {
         'http://cloud-3.steamusercontent.com/ugc/1011564617603310940/57C9EFE75A9F4FF4D9D91408490376F9A924F0D8/',
         'http://cloud-3.steamusercontent.com/ugc/1012691054073740363/8D2F90EAAAB0FA300D055DA335E392F4AA7F6852/'
     },
-    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691209063381845/5B391F2A750B852786D95A10BEBEB61146C98638/',
-    player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691209063382179/30899673366803E55F42EF7262BA1086D1778B22/'
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691401814459030/CC29D45DDBE1A471538B7E78ACA097D527B8F8CC/',
+    player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691401814458523/75C0C25445C1D8DE41B6FE5790B519C382B2ADAF/'
 }
 
 troop_bowman_late_medieval = {
@@ -564,8 +583,8 @@ troop_crossbowman_late_medieval = {
         'http://cloud-3.steamusercontent.com/ugc/1011564883556587575/E54B651B50F420A40624A88F96A76D6A9BAC5F06/',
         'http://cloud-3.steamusercontent.com/ugc/1011564883556587879/A8095395095E289CB397F95FAF9F392C841580AF/'
     },
-    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691209063381845/5B391F2A750B852786D95A10BEBEB61146C98638/',
-    player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691209063382179/30899673366803E55F42EF7262BA1086D1778B22/'
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691401814459030/CC29D45DDBE1A471538B7E78ACA097D527B8F8CC/',
+    player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691401814458523/75C0C25445C1D8DE41B6FE5790B519C382B2ADAF/'
 }
 
 troop_swordman_late_medieval = {
@@ -590,8 +609,8 @@ troop_swordman_late_medieval = {
         'http://cloud-3.steamusercontent.com/ugc/1011564883555628768/5F92C6D0BD1870F75B7E8219310EF8F67F984C30/',
         'http://cloud-3.steamusercontent.com/ugc/1011564883555629068/CF8F13836A44A95E9834A5150EC14D37B4B7FE5A/'
     },
-    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691209063381845/5B391F2A750B852786D95A10BEBEB61146C98638/',
-    player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691209063382179/30899673366803E55F42EF7262BA1086D1778B22/'
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691401814459030/CC29D45DDBE1A471538B7E78ACA097D527B8F8CC/',
+    player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691401814458523/75C0C25445C1D8DE41B6FE5790B519C382B2ADAF/'
 }
 
 troop_swordman_two_handed_late_medieval = {
@@ -611,8 +630,8 @@ troop_swordman_two_handed_late_medieval = {
         'http://cloud-3.steamusercontent.com/ugc/1011564883555798980/6C3B8086B07DC45AB601D8B6691B992B93EE7A9D/',
         'http://cloud-3.steamusercontent.com/ugc/1011564883555799315/124423D498E29D29B87C81EA090A0A9ED6FA9F49/'
     },
-    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691209063381845/5B391F2A750B852786D95A10BEBEB61146C98638/',
-    player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691209063382179/30899673366803E55F42EF7262BA1086D1778B22/'
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691401814459030/CC29D45DDBE1A471538B7E78ACA097D527B8F8CC/',
+    player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691401814458523/75C0C25445C1D8DE41B6FE5790B519C382B2ADAF/'
 }
 
 troop_artillery_pieces_late_medieval = {
@@ -723,6 +742,19 @@ troop_knight_late_medieval_bannerman = {
     player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691328068101058/6F8A8AC48C788DA465D7A8FEA1AB18D237B93995/'
 }
 
+troop_war_wagon_late_medieval = {
+    height_correction = 0.4,
+    scale = 0.42,
+    rotation = 0,
+    description = 'Late Medieval War Wagon',
+    author = 'Late Medieval War Wagon, using Empire crossbowmen by Vess, cart and lateral items barriers by Bog Hardlog (all models and textures edited by Arkein).',
+    mesh = {
+        'http://cloud-3.steamusercontent.com/ugc/1012691401814459987/F1D15FB8BE976CB22B591A5488F1645308AB2E47/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691401814459030/CC29D45DDBE1A471538B7E78ACA097D527B8F8CC/',
+    player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691401814458523/75C0C25445C1D8DE41B6FE5790B519C382B2ADAF/'
+}
+
 troop_camp_late_medieval = {
   height_correction = 0,
   scale = 0.028 ,
@@ -735,5 +767,23 @@ troop_camp_late_medieval = {
 
     },
     player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691108385863633/F4AF3441E409E2332B39871D2C4BA24D191E31C5/',
+    player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691108385864161/CC79CEAB62CAEBC7B4A1C9424603E729BF4B6CD4/'
+}
+
+------------------------------------------------------------------------------
+--                            LATE GERMAN
+------------------------------------------------------------------------------
+troop_camp_late_german = {
+  height_correction = 0,
+  scale = 0.028 ,
+    rotation = 0,
+    description = 'Late Medieval Camp',
+    author = 'Late Medieval Camp, using Empire Camp by Vess (edited by Arkein).',
+    mesh = {
+        'http://cloud-3.steamusercontent.com/ugc/1011564754631755610/F53454B6AD7674E2867551A549EC6AAB7797F032/',
+        'http://cloud-3.steamusercontent.com/ugc/1011564754634704049/BD4E1F2332E028516026E373B068FA69DBF931D4/'
+
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691401814556787/089DD3D7BD4CDB6F65A163CDA20CE876BAACC57E/',
     player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1012691108385864161/CC79CEAB62CAEBC7B4A1C9424603E729BF4B6CD4/'
 }


### PR DESCRIPTION
Added Generic War Wagon. It uses the texture of the infantry for the crew so I had to modify it to include all the wagon textures. So I modified all the infantry URLs textures.

I also added spearmen with shields. The un-shielded ones were made to represent irish kern (although I am using it to all the 3Sp bases for now), and the new spearmen shielded are more like european militia. I already had the models, just uploaded them and added to this file.

And last, I added a new campament for the late german army I made. It has the sacred empire banner (although the blue player still uses the generic one).