### PR TITLE
Plain bases and general token added

### DIFF
--- a/scripts/data_troops.ttslua
+++ b/scripts/data_troops.ttslua
@@ -131,6 +131,528 @@ tile_grass_40x80 = {
 }
 
 -------------------------------------------------------------------------------
+--                          PLAIN BASES TILES
+-------------------------------------------------------------------------------
+
+tile_plain_4Bd_40x15 = {
+    height_correction = 0,
+    scale = 1,
+    rotation = 0,
+    depth = 15,
+    description = '40x15 4Bd Tile',
+    author = 'Plain tile, original work by Arkein (model) and Eric Delemer (texture), using troop icon from Lorenzo Moro.',
+    mesh = { 'http://cloud-3.steamusercontent.com/ugc/1018321288887124159/81880B83C6F04FCE4677049EF59874FA45A6FE23/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1018321288887139503/BAA942D3D370D2701468BAEC3648B70FD8A29466/',
+    player_blue_tex= 'http://cloud-3.steamusercontent.com/ugc/1018321288887139854/5DCA6064A3770336BD79FCDDAFBA47EF24BB285B/'
+}
+
+tile_plain_4Pk_40x15 = {
+    height_correction = 0,
+    scale = 1,
+    rotation = 0,
+    depth = 15,
+    description = '40x15 4Pk Tile',
+    author = 'Plain tile, original work by Arkein (model) and Eric Delemer (texture), using troop icon from Lorenzo Moro.',
+    mesh = { 'http://cloud-3.steamusercontent.com/ugc/1018321288887124411/C58EBEE310D369CE808C8FA4CAD04EA999B8C1BE/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1018321288887139503/BAA942D3D370D2701468BAEC3648B70FD8A29466/',
+    player_blue_tex= 'http://cloud-3.steamusercontent.com/ugc/1018321288887139854/5DCA6064A3770336BD79FCDDAFBA47EF24BB285B/'
+}
+
+tile_plain_4Wb_40x15 = {
+    height_correction = 0,
+    scale = 1,
+    rotation = 0,
+    depth = 15,
+    description = '40x15 4Wb Tile',
+    author = 'Plain tile, original work by Arkein (model) and Eric Delemer (texture), using troop icon from Lorenzo Moro.',
+    mesh = { 'http://cloud-3.steamusercontent.com/ugc/1018321288887124636/32AF311F312EC8D7EAB496DAA741B208C08901EE/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1018321288887139503/BAA942D3D370D2701468BAEC3648B70FD8A29466/',
+    player_blue_tex= 'http://cloud-3.steamusercontent.com/ugc/1018321288887139854/5DCA6064A3770336BD79FCDDAFBA47EF24BB285B/'
+}
+
+tile_plain_4Sp_40x15 = {
+    height_correction = 0,
+    scale = 1,
+    rotation = 0,
+    depth = 15,
+    description = '40x15 4Sp Tile',
+    author = 'Plain tile, original work by Arkein (model) and Eric Delemer (texture), using troop icon from Lorenzo Moro.',
+    mesh = { 'http://cloud-3.steamusercontent.com/ugc/1018321288887125428/07816CA7E30A38527393D97B1A4B28C7868CDC35/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1018321288887139503/BAA942D3D370D2701468BAEC3648B70FD8A29466/',
+    player_blue_tex= 'http://cloud-3.steamusercontent.com/ugc/1018321288887139854/5DCA6064A3770336BD79FCDDAFBA47EF24BB285B/'
+}
+
+tile_plain_2Ps_40x20 = {
+    height_correction = 0,
+    scale = 1,
+    rotation = 0,
+    depth = 20,
+    description = '40x20 2Ps Tile ',
+    author = 'Plain tile, original work by Arkein (model) and Eric Delemer (texture), using troop icon from Lorenzo Moro.',
+    mesh = { 'http://cloud-3.steamusercontent.com/ugc/1018321288887125703/064FD7B135658C3D7729D0B590E5FA0CD20F2AC7/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1018321288887139503/BAA942D3D370D2701468BAEC3648B70FD8A29466/',
+    player_blue_tex= 'http://cloud-3.steamusercontent.com/ugc/1018321288887139854/5DCA6064A3770336BD79FCDDAFBA47EF24BB285B/'
+}
+
+tile_plain_3Ax_40x20 = {
+    height_correction = 0,
+    scale = 1,
+    rotation = 0,
+    depth = 20,
+    description = '40x20 3Ax Tile',
+    author = 'Plain tile, original work by Arkein (model) and Eric Delemer (texture), using troop icon from Lorenzo Moro.',
+    mesh = { 'http://cloud-3.steamusercontent.com/ugc/1018321288887125950/417AA8879D4E03677D4A83D6592D21CC1C530741/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1018321288887139503/BAA942D3D370D2701468BAEC3648B70FD8A29466/',
+    player_blue_tex= 'http://cloud-3.steamusercontent.com/ugc/1018321288887139854/5DCA6064A3770336BD79FCDDAFBA47EF24BB285B/'
+}
+
+tile_plain_3Bd_40x20 = {
+    height_correction = 0,
+    scale = 1,
+    rotation = 0,
+    depth = 20,
+    description = '40x20 3Bd Tile',
+    author = 'Plain tile, original work by Arkein (model) and Eric Delemer (texture), using troop icon from Lorenzo Moro.',
+    mesh = { 'http://cloud-3.steamusercontent.com/ugc/1018321288887126234/7F9C1FC73154FC49CC722E3B124C9DEA45FEE46D/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1018321288887139503/BAA942D3D370D2701468BAEC3648B70FD8A29466/',
+    player_blue_tex= 'http://cloud-3.steamusercontent.com/ugc/1018321288887139854/5DCA6064A3770336BD79FCDDAFBA47EF24BB285B/'
+}
+
+tile_plain_3Bw_40x20 = {
+    height_correction = 0,
+    scale = 1,
+    rotation = 0,
+    depth = 20,
+    description = '40x20 3Bw Tile',
+    author = 'Plain tile, original work by Arkein (model) and Eric Delemer (texture), using troop icon from Lorenzo Moro.',
+    mesh = { 'http://cloud-3.steamusercontent.com/ugc/1018321288887126602/7E8E0CDA2343C8AE3E5F6A9ED171BBAC26D8D8CB/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1018321288887139503/BAA942D3D370D2701468BAEC3648B70FD8A29466/',
+    player_blue_tex= 'http://cloud-3.steamusercontent.com/ugc/1018321288887139854/5DCA6064A3770336BD79FCDDAFBA47EF24BB285B/'
+}
+
+tile_plain_3Cb_40x20 = {
+    height_correction = 0,
+    scale = 1,
+    rotation = 0,
+    depth = 20,
+    description = '40x20 3Cb Tile',
+    author = 'Plain tile, original work by Arkein (model) and Eric Delemer (texture), using troop icon from Lorenzo Moro.',
+    mesh = { 'http://cloud-3.steamusercontent.com/ugc/1018321288887126862/4524834F42C198D0931C0ED3D8B3A8257E406C9F/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1018321288887139503/BAA942D3D370D2701468BAEC3648B70FD8A29466/',
+    player_blue_tex= 'http://cloud-3.steamusercontent.com/ugc/1018321288887139854/5DCA6064A3770336BD79FCDDAFBA47EF24BB285B/'
+}
+
+tile_plain_3Lb_40x20 = {
+    height_correction = 0,
+    scale = 1,
+    rotation = 0,
+    depth = 20,
+    description = '40x20 3Lb Tile',
+    author = 'Plain tile, original work by Arkein (model) and Eric Delemer (texture), using troop icon from Lorenzo Moro.',
+    mesh = { 'http://cloud-3.steamusercontent.com/ugc/1018321288887127112/C6CA5E9AEAC1490B5730EF89AAFE6B8433DDF5FE/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1018321288887139503/BAA942D3D370D2701468BAEC3648B70FD8A29466/',
+    player_blue_tex= 'http://cloud-3.steamusercontent.com/ugc/1018321288887139854/5DCA6064A3770336BD79FCDDAFBA47EF24BB285B/'
+}
+
+tile_plain_3Sp_40x20 = {
+    height_correction = 0,
+    scale = 1,
+    rotation = 0,
+    depth = 20,
+    description = '40x20 3Sp Tile',
+    author = 'Plain tile, original work by Arkein (model) and Eric Delemer (texture), using troop icon from Lorenzo Moro.',
+    mesh = { 'http://cloud-3.steamusercontent.com/ugc/1018321288887127632/326EFA40219090729A147619BB86153F57FAB18B/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1018321288887139503/BAA942D3D370D2701468BAEC3648B70FD8A29466/',
+    player_blue_tex= 'http://cloud-3.steamusercontent.com/ugc/1018321288887139854/5DCA6064A3770336BD79FCDDAFBA47EF24BB285B/'
+}
+
+tile_plain_3Wb_40x20 = {
+    height_correction = 0,
+    scale = 1,
+    rotation = 0,
+    depth = 20,
+    description = '40x20 3Wb Tile',
+    author = 'Plain tile, original work by Arkein (model) and Eric Delemer (texture), using troop icon from Lorenzo Moro.',
+    mesh = { 'http://cloud-3.steamusercontent.com/ugc/1018321288887127954/2F1A6F28A544E4FBE4E698BBAB34CC8298E53A5D/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1018321288887139503/BAA942D3D370D2701468BAEC3648B70FD8A29466/',
+    player_blue_tex= 'http://cloud-3.steamusercontent.com/ugc/1018321288887139854/5DCA6064A3770336BD79FCDDAFBA47EF24BB285B/'
+}
+
+tile_plain_4Ax_40x20 = {
+    height_correction = 0,
+    scale = 1,
+    rotation = 0,
+    depth = 20,
+    description = '40x20 4Ax Tile',
+    author = 'Plain tile, original work by Arkein (model) and Eric Delemer (texture), using troop icon from Lorenzo Moro.',
+    mesh = { 'http://cloud-3.steamusercontent.com/ugc/1018321288887128271/FDC446BD30718AE5BCF9CB8A93501A38EED3616F/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1018321288887139503/BAA942D3D370D2701468BAEC3648B70FD8A29466/',
+    player_blue_tex= 'http://cloud-3.steamusercontent.com/ugc/1018321288887139854/5DCA6064A3770336BD79FCDDAFBA47EF24BB285B/'
+}
+
+tile_plain_4Bw_40x20 = {
+    height_correction = 0,
+    scale = 1,
+    rotation = 0,
+    depth = 20,
+    description = '40x20 4Bw Tile',
+    author = 'Plain tile, original work by Arkein (model) and Eric Delemer (texture), using troop icon from Lorenzo Moro.',
+    mesh = { 'http://cloud-3.steamusercontent.com/ugc/1018321288887128565/5369DCD717A3A02B854CEE446F22B19B2DB2D0D3/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1018321288887139503/BAA942D3D370D2701468BAEC3648B70FD8A29466/',
+    player_blue_tex= 'http://cloud-3.steamusercontent.com/ugc/1018321288887139854/5DCA6064A3770336BD79FCDDAFBA47EF24BB285B/'
+}
+
+tile_plain_4Cb_40x20 = {
+    height_correction = 0,
+    scale = 1,
+    rotation = 0,
+    depth = 20,
+    description = '40x20 4Cb Tile',
+    author = 'Plain tile, original work by Arkein (model) and Eric Delemer (texture), using troop icon from Lorenzo Moro.',
+    mesh = { 'http://cloud-3.steamusercontent.com/ugc/1018321288887128834/B3AD485A4027028DE44B7A474FCF6C7F4C83743A/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1018321288887139503/BAA942D3D370D2701468BAEC3648B70FD8A29466/',
+    player_blue_tex= 'http://cloud-3.steamusercontent.com/ugc/1018321288887139854/5DCA6064A3770336BD79FCDDAFBA47EF24BB285B/'
+}
+
+tile_plain_4Lb_40x20 = {
+    height_correction = 0,
+    scale = 1,
+    rotation = 0,
+    depth = 20,
+    description = '40x20 4Lb Tile',
+    author = 'Plain tile, original work by Arkein (model) and Eric Delemer (texture), using troop icon from Lorenzo Moro.',
+    mesh = { 'http://cloud-3.steamusercontent.com/ugc/1018321288887129132/7A29DCD0C420029AB7DEA7AE186C9E74609DB14D/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1018321288887139503/BAA942D3D370D2701468BAEC3648B70FD8A29466/',
+    player_blue_tex= 'http://cloud-3.steamusercontent.com/ugc/1018321288887139854/5DCA6064A3770336BD79FCDDAFBA47EF24BB285B/'
+}
+
+tile_plain_Camp_Followers_40x20 = {
+    height_correction = 0,
+    scale = 1,
+    rotation = 0,
+    depth = 20,
+    description = '40x20 Camp Followers Tile',
+    author = 'Plain tile, original work by Arkein (model) and Eric Delemer (texture), using troop icon from Lorenzo Moro.',
+    mesh = { 'http://cloud-3.steamusercontent.com/ugc/1018321288887129410/AB772564BA2936D0F4659D1DCDFD1C772E5CF248/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1018321288887139503/BAA942D3D370D2701468BAEC3648B70FD8A29466/',
+    player_blue_tex= 'http://cloud-3.steamusercontent.com/ugc/1018321288887139854/5DCA6064A3770336BD79FCDDAFBA47EF24BB285B/'
+}
+
+tile_plain_2Cm_40x30 = {
+    height_correction = 0,
+    scale = 1,
+    rotation = 0,
+    depth = 30,
+    description = '40x30 2Cm Tile',
+    author = 'Plain tile, original work by Arkein (model) and Eric Delemer (texture), using troop icon from Lorenzo Moro.',
+    mesh = { 'http://cloud-3.steamusercontent.com/ugc/1018321288887129693/913021784A88AA30E336383F34823E198EC98950/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1018321288887139503/BAA942D3D370D2701468BAEC3648B70FD8A29466/',
+    player_blue_tex= 'http://cloud-3.steamusercontent.com/ugc/1018321288887139854/5DCA6064A3770336BD79FCDDAFBA47EF24BB285B/'
+}
+
+tile_plain_2LH_40x30 = {
+    height_correction = 0,
+    scale = 1,
+    rotation = 0,
+    depth = 30,
+    description = '40x30 2LH Tile',
+    author = 'Plain tile, original work by Arkein (model) and Eric Delemer (texture), using troop icon from Lorenzo Moro.',
+    mesh = { 'http://cloud-3.steamusercontent.com/ugc/1018321288887129958/C6FAE67CDC6206957446F13C7AAC65085C101B83/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1018321288887139503/BAA942D3D370D2701468BAEC3648B70FD8A29466/',
+    player_blue_tex= 'http://cloud-3.steamusercontent.com/ugc/1018321288887139854/5DCA6064A3770336BD79FCDDAFBA47EF24BB285B/'
+}
+
+tile_plain_3Cm_40x30 = {
+    height_correction = 0,
+    scale = 1,
+    rotation = 0,
+    depth = 30,
+    description = '40x30 3Cm Tile',
+    author = 'Plain tile, original work by Arkein (model) and Eric Delemer (texture), using troop icon from Lorenzo Moro.',
+    mesh = { 'http://cloud-3.steamusercontent.com/ugc/1018321288887130240/B1454E57D0427EA89F02D37AD2A37D969EC8224A/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1018321288887139503/BAA942D3D370D2701468BAEC3648B70FD8A29466/',
+    player_blue_tex= 'http://cloud-3.steamusercontent.com/ugc/1018321288887139854/5DCA6064A3770336BD79FCDDAFBA47EF24BB285B/'
+}
+
+tile_plain_3Cv_40x30 = {
+    height_correction = 0,
+    scale = 1,
+    rotation = 0,
+    depth = 30,
+    description = '40x30 3Cv Tile',
+    author = 'Plain tile, original work by Arkein (model) and Eric Delemer (texture), using troop icon from Lorenzo Moro.',
+    mesh = { 'http://cloud-3.steamusercontent.com/ugc/1018321288887130506/DD74D9EC299B453FD3B04C9F7E4ABCDE8D2AC521/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1018321288887139503/BAA942D3D370D2701468BAEC3648B70FD8A29466/',
+    player_blue_tex= 'http://cloud-3.steamusercontent.com/ugc/1018321288887139854/5DCA6064A3770336BD79FCDDAFBA47EF24BB285B/'
+}
+
+tile_plain_3Kn_40x30 = {
+    height_correction = 0,
+    scale = 1,
+    rotation = 0,
+    depth = 30,
+    description = '40x30 3Kn Tile',
+    author = 'Plain tile, original work by Arkein (model) and Eric Delemer (texture), using troop icon from Lorenzo Moro.',
+    mesh = { 'http://cloud-3.steamusercontent.com/ugc/1018321288887131655/525C649990C8D1D8BA88E0183AEB6423F5EB4785/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1018321288887139503/BAA942D3D370D2701468BAEC3648B70FD8A29466/',
+    player_blue_tex= 'http://cloud-3.steamusercontent.com/ugc/1018321288887139854/5DCA6064A3770336BD79FCDDAFBA47EF24BB285B/'
+}
+
+tile_plain_4Kn_40x30 = {
+    height_correction = 0,
+    scale = 1,
+    rotation = 0,
+    depth = 30,
+    description = '40x30 4Kn Tile',
+    author = 'Plain tile, original work by Arkein (model) and Eric Delemer (texture), using troop icon from Lorenzo Moro.',
+    mesh = { 'http://cloud-3.steamusercontent.com/ugc/1018321288887132019/B5834A63DCA8B94E32EAAE59FD9DD4EEABF4E59C/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1018321288887139503/BAA942D3D370D2701468BAEC3648B70FD8A29466/',
+    player_blue_tex= 'http://cloud-3.steamusercontent.com/ugc/1018321288887139854/5DCA6064A3770336BD79FCDDAFBA47EF24BB285B/'
+}
+
+tile_plain_7Hd_40x30 = {
+    height_correction = 0,
+    scale = 1,
+    rotation = 0,
+    depth = 30,
+    description = '40x30 7Hd Tile',
+    author = 'Plain tile, original work by Arkein (model) and Eric Delemer (texture), using troop icon from Lorenzo Moro.',
+    mesh = { 'http://cloud-3.steamusercontent.com/ugc/1018321288887133106/9EBBC6302BC1224DEF5BBB73FF430DB294F09CE0/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1018321288887139503/BAA942D3D370D2701468BAEC3648B70FD8A29466/',
+    player_blue_tex= 'http://cloud-3.steamusercontent.com/ugc/1018321288887139854/5DCA6064A3770336BD79FCDDAFBA47EF24BB285B/'
+}
+
+tile_plain_6Bd_40x40 = {
+    height_correction = 0,
+    scale = 1,
+    rotation = 0,
+    depth = 40,
+    description = '40x40 6Bd Tile',
+    author = 'Plain tile, original work by Arkein (model) and Eric Delemer (texture), using troop icon from Lorenzo Moro.',
+    mesh = { 'http://cloud-3.steamusercontent.com/ugc/1018321288887133554/397C7778D8E8F12C7DF4F04992F96182E379166E/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1018321288887139503/BAA942D3D370D2701468BAEC3648B70FD8A29466/',
+    player_blue_tex= 'http://cloud-3.steamusercontent.com/ugc/1018321288887139854/5DCA6064A3770336BD79FCDDAFBA47EF24BB285B/'
+}
+
+tile_plain_8Bw_40x40 = {
+    height_correction = 0,
+    scale = 1,
+    rotation = 0,
+    depth = 40,
+    description = '40x40 8Bw Tile',
+    author = 'Plain tile, original work by Arkein (model) and Eric Delemer (texture), using troop icon from Lorenzo Moro.',
+    mesh = { 'http://cloud-3.steamusercontent.com/ugc/1018321288887133899/58B7B4FDDE7FF613B5D882E5DDAF3CF8FBE635D6/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1018321288887139503/BAA942D3D370D2701468BAEC3648B70FD8A29466/',
+    player_blue_tex= 'http://cloud-3.steamusercontent.com/ugc/1018321288887139854/5DCA6064A3770336BD79FCDDAFBA47EF24BB285B/'
+}
+
+tile_plain_8Cb_40x40 = {
+    height_correction = 0,
+    scale = 1,
+    rotation = 0,
+    depth = 40,
+    description = '40x40 8Cb Tile',
+    author = 'Plain tile, original work by Arkein (model) and Eric Delemer (texture), using troop icon from Lorenzo Moro.',
+    mesh = { 'http://cloud-3.steamusercontent.com/ugc/1018321288887134231/EDCAD43FADD0F599B92AC76170F088BD47ED3D01/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1018321288887139503/BAA942D3D370D2701468BAEC3648B70FD8A29466/',
+    player_blue_tex= 'http://cloud-3.steamusercontent.com/ugc/1018321288887139854/5DCA6064A3770336BD79FCDDAFBA47EF24BB285B/'
+}
+
+tile_plain_8Lb_40x40 = {
+    height_correction = 0,
+    scale = 1,
+    rotation = 0,
+    depth = 40,
+    description = '40x40 8Lb Tile',
+    author = 'Plain tile, original work by Arkein (model) and Eric Delemer (texture), using troop icon from Lorenzo Moro.',
+    mesh = { 'http://cloud-3.steamusercontent.com/ugc/1018321288887209633/874EE98B6D8A2A95E19A8DFF1EC799A4F9449F1B/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1018321288887139503/BAA942D3D370D2701468BAEC3648B70FD8A29466/',
+    player_blue_tex= 'http://cloud-3.steamusercontent.com/ugc/1018321288887139854/5DCA6064A3770336BD79FCDDAFBA47EF24BB285B/'
+}
+
+tile_plain_Art_40x40 = {
+    height_correction = 0,
+    scale = 1,
+    rotation = 0,
+    depth = 40,
+    description = '40x40 Art Tile',
+    author = 'Plain tile, original work by Arkein (model) and Eric Delemer (texture), using troop icon from Lorenzo Moro.',
+    mesh = { 'http://cloud-3.steamusercontent.com/ugc/1018321288887134521/23FC48461A45BF18BDE0D28033E32088A3AC651D/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1018321288887139503/BAA942D3D370D2701468BAEC3648B70FD8A29466/',
+    player_blue_tex= 'http://cloud-3.steamusercontent.com/ugc/1018321288887139854/5DCA6064A3770336BD79FCDDAFBA47EF24BB285B/'
+}
+
+tile_plain_El_40x40 = {
+    height_correction = 0,
+    scale = 1,
+    rotation = 0,
+    depth = 40,
+    description = '40x40 El Tile',
+    author = 'Plain tile, original work by Arkein (model) and Eric Delemer (texture), using troop icon from Lorenzo Moro.',
+    mesh = { 'http://cloud-3.steamusercontent.com/ugc/1018321288887135151/23E4B7EE9F5B1A160A2E8AF0EC5D959C2FEE8861/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1018321288887139503/BAA942D3D370D2701468BAEC3648B70FD8A29466/',
+    player_blue_tex= 'http://cloud-3.steamusercontent.com/ugc/1018321288887139854/5DCA6064A3770336BD79FCDDAFBA47EF24BB285B/'
+}
+
+tile_plain_HCh_40x40 = {
+    height_correction = 0,
+    scale = 1,
+    rotation = 0,
+    depth = 40,
+    description = '40x40 HCh Tile',
+    author = 'Plain tile, original work by Arkein (model) and Eric Delemer (texture), using troop icon from Lorenzo Moro.',
+    mesh = { 'http://cloud-3.steamusercontent.com/ugc/1018321288887135442/A395F69C8F1D996AE0270A18764D1E88FA0C51A6/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1018321288887139503/BAA942D3D370D2701468BAEC3648B70FD8A29466/',
+    player_blue_tex= 'http://cloud-3.steamusercontent.com/ugc/1018321288887139854/5DCA6064A3770336BD79FCDDAFBA47EF24BB285B/'
+}
+
+tile_plain_LCh_40x40 = {
+    height_correction = 0,
+    scale = 1,
+    rotation = 0,
+    depth = 40,
+    description = '40x40 LCh Tile',
+    author = 'Plain tile, original work by Arkein (model) and Eric Delemer (texture), using troop icon from Lorenzo Moro.',
+    mesh = { 'http://cloud-3.steamusercontent.com/ugc/1018321288887135726/6FAC9BD316BC12973500F7B0A453466238B76959/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1018321288887139503/BAA942D3D370D2701468BAEC3648B70FD8A29466/',
+    player_blue_tex= 'http://cloud-3.steamusercontent.com/ugc/1018321288887139854/5DCA6064A3770336BD79FCDDAFBA47EF24BB285B/'
+}
+
+tile_plain_SCh_40x40 = {
+    height_correction = 0,
+    scale = 1,
+    rotation = 0,
+    depth = 40,
+    description = '40x40 SCh Tile',
+    author = 'Plain tile, original work by Arkein (model) and Eric Delemer (texture), using troop icon from Lorenzo Moro.',
+    mesh = { 'http://cloud-3.steamusercontent.com/ugc/1018321288887136057/4613125549CD1B934419623A44BA960CDF84B18D/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1018321288887139503/BAA942D3D370D2701468BAEC3648B70FD8A29466/',
+    player_blue_tex= 'http://cloud-3.steamusercontent.com/ugc/1018321288887139854/5DCA6064A3770336BD79FCDDAFBA47EF24BB285B/'
+}
+
+tile_plain_6Cv_40x60 = {
+    height_correction = 0,
+    scale = 1,
+    rotation = 0,
+    depth = 60,
+    description = '40x60 6Cv Tile',
+    author = 'Plain tile, original work by Arkein (model) and Eric Delemer (texture), using troop icon from Lorenzo Moro.',
+    mesh = { 'http://cloud-3.steamusercontent.com/ugc/1018321288887136410/7BC395744F564355EE3F96525AF8733FA6F38C7D/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1018321288887139503/BAA942D3D370D2701468BAEC3648B70FD8A29466/',
+    player_blue_tex= 'http://cloud-3.steamusercontent.com/ugc/1018321288887139854/5DCA6064A3770336BD79FCDDAFBA47EF24BB285B/'
+}
+
+tile_plain_6Kn_40x60 = {
+    height_correction = 0,
+    scale = 1,
+    rotation = 0,
+    depth = 60,
+    description = '40x60 6Kn Tile',
+    author = 'Plain tile, original work by Arkein (model) and Eric Delemer (texture), using troop icon from Lorenzo Moro.',
+    mesh = { 'http://cloud-3.steamusercontent.com/ugc/1018321288887136948/5535FFFBE451C66C35B35649DCDB4426ED1D2CEF/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1018321288887139503/BAA942D3D370D2701468BAEC3648B70FD8A29466/',
+    player_blue_tex= 'http://cloud-3.steamusercontent.com/ugc/1018321288887139854/5DCA6064A3770336BD79FCDDAFBA47EF24BB285B/'
+}
+
+tile_plain_Lit_40x80 = {
+    height_correction = 0,
+    scale = 1,
+    rotation = 0,
+    depth = 80,
+    description = '40x80 Lit Tile  ',
+    author = 'Plain tile, original work by Arkein (model) and Eric Delemer (texture), using troop icon from Lorenzo Moro.',
+    mesh = { 'http://cloud-3.steamusercontent.com/ugc/1018321288887137796/BEBFA5DF6BBA9037899AECF50EE12DAE0811EAD6/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1018321288887139503/BAA942D3D370D2701468BAEC3648B70FD8A29466/',
+    player_blue_tex= 'http://cloud-3.steamusercontent.com/ugc/1018321288887139854/5DCA6064A3770336BD79FCDDAFBA47EF24BB285B/'
+}
+
+tile_plain_WWg_40x80 = {
+    height_correction = 0,
+    scale = 1,
+    rotation = 0,
+    depth = 80,
+    description = '40x80 WWg Tile  ',
+    author = 'Plain tile, original work by Arkein (model) and Eric Delemer (texture), using troop icon from Lorenzo Moro .',
+    mesh = { 'http://cloud-3.steamusercontent.com/ugc/1018321288887137362/EE2562A2132A766097885663E7BB7535148EDF13/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1018321288887139503/BAA942D3D370D2701468BAEC3648B70FD8A29466/',
+    player_blue_tex= 'http://cloud-3.steamusercontent.com/ugc/1018321288887139854/5DCA6064A3770336BD79FCDDAFBA47EF24BB285B/'
+}
+
+tile_plain_Camp_40x40 = {
+    height_correction = 0,
+    scale = 1,
+    rotation = 0,
+    depth = 80,
+    description = '40x80 WWg Tile  ',
+    author = 'Plain tile, original work by Arkein using clipart.email camp drawing.',
+    mesh = { 'http://cloud-3.steamusercontent.com/ugc/1018321288887137362/EE2562A2132A766097885663E7BB7535148EDF13/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1018321288887139503/BAA942D3D370D2701468BAEC3648B70FD8A29466/',
+    player_blue_tex= 'http://cloud-3.steamusercontent.com/ugc/1018321288887139854/5DCA6064A3770336BD79FCDDAFBA47EF24BB285B/'
+}
+
+-------------------------------------------------------------------------------
+--                            PLAIN BASES TROOPS
+-------------------------------------------------------------------------------
+
+troop_general_plain = {
+    height_correction = 1
+    scale = 1,
+    rotation = 0,
+    description = 'General Token',
+    author = 'General Token, original work by Arkein (model) and Eric Delemer (texture), using troop icon from Lorenzo Moro.',
+    mesh = {
+        'http://cloud-3.steamusercontent.com/ugc/1022822649627337225/1437C085D4FFF74C2FBF2286FAFA4C555FA9AAAA/',
+        'http://cloud-3.steamusercontent.com/ugc/1022822649628563080/2F543EB07AA1B046FA49FCA7C9EF67194D266DD2/',
+        'http://cloud-3.steamusercontent.com/ugc/1022822649628565149/C08A32327A4329E24B03884EC8E9B00EDE08E102/',
+        'http://cloud-3.steamusercontent.com/ugc/1022822649628566503/035642E0FAE5DF4B5CEBC6434BAB41FC18EEF8E0/',
+        'http://cloud-3.steamusercontent.com/ugc/1022822649628567927/AE5F2D0422FDF434229A78A9E50438FF8B1E6349/',
+        'http://cloud-3.steamusercontent.com/ugc/1022822649628569273/FA02A88651EB70329816666DB1834AA119A943DB/',
+        'http://cloud-3.steamusercontent.com/ugc/1022822649628570664/C8F15D793175D0A6597B4A60BE790FDD5B503A1A/',
+        'http://cloud-3.steamusercontent.com/ugc/1022822649628571770/5F92C6D0BD1870F75B7E8219310EF8F67F984C30/'
+    },
+    player_red_tex = 'http://cloud-3.steamusercontent.com/ugc/1022822649627341435/6849CB89095D43654125ED506222AF73172C09C1/',
+    player_blue_tex = 'http://cloud-3.steamusercontent.com/ugc/1022822649627338507/BBA5455E7C52A92432746B828602DFAEB68142D2/'
+}
+
+-------------------------------------------------------------------------------
 --                                   TROOPS
 -------------------------------------------------------------------------------
 


### PR DESCRIPTION
I added the plain bases with their texture for both blue and red players on the TILES section.

I also created a "PLAIN BASES TROOPS" for the plain general token, in case we want to add something else in the future and, since it won't behave as a base but as a troop model, I thought it was better to separate them.